### PR TITLE
Remove some indirection around unions

### DIFF
--- a/pants_plugins/sendwave/pants_docker/docker_component.py
+++ b/pants_plugins/sendwave/pants_docker/docker_component.py
@@ -1,10 +1,8 @@
 import logging
-from abc import ABC
 from dataclasses import dataclass
-from typing import ClassVar, List, Tuple, Type
+from typing import Tuple
 
 from pants.engine.fs import Digest
-from pants.engine.target import FieldSet, Targets
 from pants.engine.unions import UnionMembership, union
 
 logger = logging.getLogger(__name__)
@@ -18,20 +16,5 @@ class DockerComponent:
 
 
 @union
-class DockerComponentRequest(ABC):
-    field_set_type: ClassVar[Type[FieldSet]]
-    fs: FieldSet
-
-    def __init__(self, field_set) -> None:
-        self.fs = field_set
-
-
-def from_dependencies(
-    tgts: Targets, um: UnionMembership
-) -> List[DockerComponentRequest]:
-    return [
-        request_type(request_type.field_set_type.create(tgt))
-        for tgt in tgts
-        for request_type in um[DockerComponentRequest]
-        if request_type.field_set_type.is_applicable(tgt)
-    ]
+class DockerComponentFieldSet:
+    pass

--- a/pants_plugins/sendwave/pants_docker/sources.py
+++ b/pants_plugins/sendwave/pants_docker/sources.py
@@ -8,69 +8,57 @@ from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Sources
 from pants.engine.unions import UnionRule
 from sendwave.pants_docker.docker_component import (DockerComponent,
-                                                    DockerComponentRequest)
+                                                    DockerComponentFieldSet)
 
 
 @dataclass(frozen=True)
-class DockerFiles(FieldSet):
+class DockerFilesFS(FieldSet):
     required_fields = (FilesSources,)
     sources: FilesSources
 
 
-class DockerFilesRequest(DockerComponentRequest):
-    field_set_type = DockerFiles
-
-
 @rule
-async def get_files(req: DockerFilesRequest) -> DockerComponent:
+async def get_files(field_set: DockerFilesFS) -> DockerComponent:
     return DockerComponent(
         commands=(),
         sources=(
-            await Get(StrippedSourceFiles, SourceFilesRequest([req.fs.sources]))
+            await Get(StrippedSourceFiles, SourceFilesRequest([field_set.sources]))
         ).snapshot.digest,
     )
 
 
 @dataclass(frozen=True)
-class DockerResources(FieldSet):
+class DockerResourcesFS(FieldSet):
     required_fields = (ResourcesSources,)
     sources: ResourcesSources
 
 
-class DockerResourcesRequest(DockerComponentRequest):
-    field_set_type = DockerResources
-
-
 @rule
-async def get_resources(req: DockerResourcesRequest) -> DockerComponent:
+async def get_resources(field_set: DockerResourcesFS) -> DockerComponent:
     return DockerComponent(
         commands=(),
         sources=(
-            await Get(StrippedSourceFiles, SourceFilesRequest([req.fs.sources]))
+            await Get(StrippedSourceFiles, SourceFilesRequest([field_set.sources]))
         ).snapshot.digest,
     )
 
 
 @dataclass(frozen=True)
-class DockerPythonSources(FieldSet):
+class DockerPythonSourcesFS(FieldSet):
     required_fields = (PythonSources,)
     sources: PythonSources
 
 
-class DockerPythonSourcesRequest(DockerComponentRequest):
-    field_set_type = DockerPythonSources
-
-
 @rule
-async def get_sources(req: DockerPythonSourcesRequest) -> DockerComponent:
-    source_files = await Get(StrippedSourceFiles, SourceFilesRequest([req.fs.sources]))
+async def get_sources(field_set: DockerPythonSourcesFS) -> DockerComponent:
+    source_files = await Get(StrippedSourceFiles, SourceFilesRequest([field_set.sources]))
     return DockerComponent(commands=(), sources=source_files.snapshot.digest)
 
 
 def rules():
     return [
-        UnionRule(DockerComponentRequest, DockerPythonSourcesRequest),
-        UnionRule(DockerComponentRequest, DockerResourcesRequest),
-        UnionRule(DockerComponentRequest, DockerFilesRequest),
+        UnionRule(DockerComponentFieldSet, DockerPythonSourcesFS),
+        UnionRule(DockerComponentFieldSet, DockerResourcesFS),
+        UnionRule(DockerComponentFieldSet, DockerFilesFS),
         *collect_rules(),
     ]


### PR DESCRIPTION
There's no need for the intermediate `Request` type. This should behave the same but with less indirection.

(I did not manually test, other than making sure rule graph still runs.)