### PR TITLE
Add Options scope with Tags & Registry options

### DIFF
--- a/README
+++ b/README
@@ -23,3 +23,30 @@ See COPYING for the text of the Apache License which this package is released un
 
 
 [0] https://www.pantsbuild.org/
+
+
+
+RELEASE NOTES:
+
+0.03
+
+* Removed the 'registry' field from the docker() build target
+
+* added the docker-package.registry option to the pants-docker subsystem
+apply it to your build in a toml file like so:
+
+[docker-package]
+registry=compyman
+
+or on the command line
+PANTS_DOCKER_PACKAGE_REGISTRY=compyman ./pants package ::
+
+* Added the docker-package.tags option to the pants-docker subsystem
+  applies similarly as the registry above but is a list value. The
+  tags field on the docker build_target() remains present and will
+  still be used
+
+[docker-package]
+PANTS_DOCKER_PACKAGE_TAGS="['tag1', '$interpolated_tag-1', 'latest']"
+
+

--- a/pants_plugins/sendwave/pants_docker/BUILD
+++ b/pants_plugins/sendwave/pants_docker/BUILD
@@ -9,7 +9,7 @@ python_distribution(
     dependencies=[":pants_docker_library",],
     provides=setup_py(
         name="sendwave-pants-docker",
-        version="0.02",
+        version="0.03",
         description="Pants Plugin to automatically generate docker images from pants targets",
         author="compyman@compyman.net",
     ),

--- a/pants_plugins/sendwave/pants_docker/register.py
+++ b/pants_plugins/sendwave/pants_docker/register.py
@@ -2,6 +2,7 @@ import sendwave.pants_docker.package as package
 import sendwave.pants_docker.python_requirement as python_requirement
 import sendwave.pants_docker.sources as sources
 import sendwave.pants_docker.target as target
+import sendwave.pants_docker.subsystem as subsystem
 
 
 def rules():
@@ -10,6 +11,7 @@ def rules():
         *sources.rules(),
         *python_requirement.rules(),
         *target.rules(),
+        *subsystem.rules(),
     ]
 
 

--- a/pants_plugins/sendwave/pants_docker/subsystem.py
+++ b/pants_plugins/sendwave/pants_docker/subsystem.py
@@ -1,0 +1,32 @@
+"""Defines a subsystem which allows setting tags via the command line
+or configuration file
+"""
+from pants.engine.rules import collect_rules
+from pants.option.subsystem import Subsystem
+
+
+class DockerPackageSubsystem(Subsystem):
+    options_scope = 'docker-package'
+    help = ('Configuration for the python-docker plugin '
+            'to set the tags of the resulting image')
+
+    @classmethod
+    def register_options(cls, register):
+        """Register the 'tags' argument."""
+        super().register_options(register)
+        register(
+            '--tags',
+            type=list,
+            member_type=str,
+            help="List of tags to identify the generated image",
+        )
+        register(
+            '--registry',
+            type=str,
+            default=None,
+            help='docker registry to add to image tags',
+        )
+
+
+def rules():
+    return collect_rules()

--- a/pants_plugins/sendwave/pants_docker/target.py
+++ b/pants_plugins/sendwave/pants_docker/target.py
@@ -39,12 +39,6 @@ class WorkDir(StringField):
     help = "The directory inside the container into which"
 
 
-class Registry(StringField):
-    alias = "registry"
-    required = False
-    help = "The registry of the resulting docker image"
-
-
 class Tags(StringSequenceField):
     alias = "tags"
     default = []
@@ -63,11 +57,9 @@ class Command(StringSequenceField):
 class DockerPackageFieldSet(pants.core.goals.package.PackageFieldSet):
     alias = "docker_field_set"
     required_fields = (BaseImage,)
-
     base_image: BaseImage
     image_setup: ImageSetup
     ignore: DockerIgnore
-    registry: Registry
     tags: Tags
     dependencies: Dependencies
     workdir: WorkDir


### PR DESCRIPTION
Adds the `pants-docker` configuration scope on which you can set
1) the registry to tag the generated image
2) a list of tags for the generated image
these can be specified at build time or in the configuration file

Here's what it looks like on the command line:

    PANTS_DOCKER_PACKAGE_REGISTRY=compyman \
    PANTS_DOCKER_PACKAGE_TAGS="['$CI_PROVIDED_COMMIT']" \
    ./pants package ::`

which would result in an image tagged
`compyman/{target_name}:fa51628`

It is contains a breaking change: the registry field has been removed
from the build target instead prefering you to set it at build time or
via the config.